### PR TITLE
Improve mobile friendly layout

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -71,7 +71,12 @@ function renderFretboard() {
   const strings = tuningNotes.slice().reverse();
 
   fb.innerHTML = '';
-  fb.style.gridTemplateColumns = `repeat(${frets},90px)`;
+  const containerWidth = fb.parentElement?.clientWidth || window.innerWidth;
+  const fretWidth = Math.max(
+        minFretWidth,
+        Math.min(maxFretWidth, Math.floor(containerWidth / frets))
+  );
+  fb.style.gridTemplateColumns = `repeat(${frets},${fretWidth}px)`;
   fb.style.gridTemplateRows = `repeat(${strings.length},50px)`;
 
   document.querySelectorAll('.string-line').forEach(e => e.remove());
@@ -95,7 +100,6 @@ function renderFretboard() {
       const noteName = getNoteName(noteIndex);
       const div = document.createElement('div');
       div.className = 'fret';
-      const fretWidth = maxFretWidth - ((maxFretWidth - minFretWidth)/frets);
       div.style.width = fretWidth;
       div.dataset.fret = f;
       div.dataset.note = noteName;
@@ -148,7 +152,7 @@ function renderFretboard() {
   }
 
   lb.innerHTML = '';
-  lb.style.gridTemplateColumns = `repeat(${frets},90px)`;
+  lb.style.gridTemplateColumns = `repeat(${frets},${fretWidth}px)`;
   for (let f = 0; f < frets; f++) {
     const D = document.createElement('div');
     D.textContent = f;

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Fretboar V2</title>
 <link rel="stylesheet" href="styles.css">
 <script src="scales.js"></script> 

--- a/styles.css
+++ b/styles.css
@@ -384,4 +384,15 @@ input.active-beat {
   }
 }
 
+@media (max-width: 400px) {
+  .controls input[type="text"],
+  .controls select {
+    width: 100%;
+  }
+
+  #footerBanner {
+    position: static;
+  }
+}
+
 


### PR DESCRIPTION
## Summary
- add mobile viewport meta tag
- stretch controls to full width on very narrow screens
- allow footer banner to scroll into view on small devices
- resize frets based on available width

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68671ba13d8c832eac27dc983ba017d2