### PR TITLE
Enable pinch zoom on fretboard

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -251,6 +251,7 @@ renderFretboard();
 
 // Mobile pinch-to-zoom for fretboard only
 const fbWrapper = document.querySelector('.fretboard-wrapper');
+const baseMargin = parseFloat(getComputedStyle(fbWrapper).marginBottom) || 0;
 let zoomScale = 1;
 let startDist = 0;
 let startZoom = 1;
@@ -281,6 +282,7 @@ fbWrapper.addEventListener('pointermove', e => {
     zoomScale = Math.min(Math.max(startZoom * dist / startDist, 0.5), 3);
     fbWrapper.style.transformOrigin = '0 0';
     fbWrapper.style.transform = `scale(${zoomScale})`;
+    fbWrapper.style.marginBottom = `${baseMargin * zoomScale}px`;
   }
 });
 

--- a/fretboard.js
+++ b/fretboard.js
@@ -248,3 +248,48 @@ renderFretboard();
     renderFretboard();
   });
 });
+
+// Mobile pinch-to-zoom for fretboard only
+const fbWrapper = document.querySelector('.fretboard-wrapper');
+let zoomScale = 1;
+let startDist = 0;
+let startZoom = 1;
+const activePointers = new Map();
+
+function pointerDistance(p1, p2) {
+  const dx = p2.clientX - p1.clientX;
+  const dy = p2.clientY - p1.clientY;
+  return Math.hypot(dx, dy);
+}
+
+fbWrapper.addEventListener('pointerdown', e => {
+  activePointers.set(e.pointerId, e);
+  if (activePointers.size === 2) {
+    const pts = Array.from(activePointers.values());
+    startDist = pointerDistance(pts[0], pts[1]);
+    startZoom = zoomScale;
+  }
+});
+
+fbWrapper.addEventListener('pointermove', e => {
+  if (!activePointers.has(e.pointerId)) return;
+  activePointers.set(e.pointerId, e);
+  if (activePointers.size === 2) {
+    e.preventDefault();
+    const pts = Array.from(activePointers.values());
+    const dist = pointerDistance(pts[0], pts[1]);
+    zoomScale = Math.min(Math.max(startZoom * dist / startDist, 1), 3);
+    fbWrapper.style.transformOrigin = '0 0';
+    fbWrapper.style.transform = `scale(${zoomScale})`;
+  }
+});
+
+function endPointer(e) {
+  activePointers.delete(e.pointerId);
+  if (activePointers.size < 2) {
+    startDist = 0;
+  }
+}
+['pointerup', 'pointercancel', 'pointerleave'].forEach(type => {
+  fbWrapper.addEventListener(type, endPointer);
+});

--- a/fretboard.js
+++ b/fretboard.js
@@ -278,7 +278,7 @@ fbWrapper.addEventListener('pointermove', e => {
     e.preventDefault();
     const pts = Array.from(activePointers.values());
     const dist = pointerDistance(pts[0], pts[1]);
-    zoomScale = Math.min(Math.max(startZoom * dist / startDist, 1), 3);
+    zoomScale = Math.min(Math.max(startZoom * dist / startDist, 0.5), 3);
     fbWrapper.style.transformOrigin = '0 0';
     fbWrapper.style.transform = `scale(${zoomScale})`;
   }

--- a/styles.css
+++ b/styles.css
@@ -69,7 +69,8 @@ button:hover {
 ================================== */
 .fretboard-wrapper {
   overflow-x: auto;
-  max-width: 100%;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
   margin-bottom: 1rem;
   touch-action: pan-x pan-y;
 }

--- a/styles.css
+++ b/styles.css
@@ -71,6 +71,7 @@ button:hover {
   overflow-x: auto;
   max-width: 100%;
   margin-bottom: 1rem;
+  touch-action: pan-x pan-y;
 }
 
 .fretboard {


### PR DESCRIPTION
## Summary
- revert body touch-action rule
- allow panning within fretboard wrapper
- add pointer event handling to pinch-zoom the fretboard only

## Testing
- `node -c fretboard.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68680d341ab0832eb33d9fc6fe4d665a