### PR TITLE
Enable zoom by resizing frets

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -69,8 +69,10 @@ button:hover {
 ================================== */
 .fretboard-wrapper {
   overflow-x: auto;
-  max-width: 100%;
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
   margin-bottom: 1rem;
+  touch-action: pan-x pan-y;
 }
 
 .fretboard {


### PR DESCRIPTION
## Summary
- resize fret widths instead of scaling the whole wrapper
- update grid layouts and margins through new `applyZoom` helper
- trigger zoom updates on pinch gestures and after rendering

## Testing
- `node -c fretboard.js`
- `node -c metrognome.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68680d341ab0832eb33d9fc6fe4d665a