### PR TITLE
Add option for relative scale-based pitch coloring

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -15,6 +15,7 @@ const pitchColors = {
       "F#": "#4363d8", "G": "#911eb4",  "G#": "#f032e6",
       "A": "#a9a9a9",  "A#": "#fabebe", "B": "#ffd8b1"
 };
+const scaleDegreeColors = Object.values(pitchColors);
 
 function getNoteName(i) {
   return noteNames[i % 12];
@@ -53,7 +54,8 @@ function renderFretboard() {
   const showAll = document.getElementById('showAllNotesToggle').checked;
   const highlightRootToggle = document.getElementById('highlightRootToggle').checked;
   const pitchToggle = document.getElementById('pitchColorsToggle').checked;
-  
+  const relativeToggle = document.getElementById('relativeColorsToggle')?.checked;
+
   const rootVal = noteMap[scaleRootName] ?? '';
 
   let scaleSet = new Set();
@@ -67,6 +69,23 @@ function renderFretboard() {
   if (scaleSet.size) {
     highlightsSet.forEach(note => scaleSet.add(note));
   }
+
+  const scaleDegreeColorMap = new Map();
+  if (relativeToggle && scaleNotes.length) {
+    scaleNotes.forEach((note, index) => {
+      if (!scaleDegreeColorMap.has(note)) {
+        scaleDegreeColorMap.set(note, scaleDegreeColors[index % scaleDegreeColors.length]);
+      }
+    });
+  }
+
+  const getRingColor = (note) => {
+    if (!pitchToggle) return null;
+    if (scaleDegreeColorMap.size && scaleDegreeColorMap.has(note)) {
+      return scaleDegreeColorMap.get(note);
+    }
+    return pitchColors[note];
+  };
 
   const strings = tuningNotes.slice().reverse();
 
@@ -113,10 +132,11 @@ function renderFretboard() {
       }
 
       let pitchHighlight = (div, note, cname)=>{
-		  div.classList.add(cname);
-          if (pitchToggle) {
-			div.classList.add('ring');
-			div.style.setProperty('--ring-color', pitchColors[note]);
+                  div.classList.add(cname);
+          const ringColor = getRingColor(note);
+          if (ringColor) {
+                        div.classList.add('ring');
+                        div.style.setProperty('--ring-color', ringColor);
           }
       };
       if (window.playCount > 0 && noteName == window.metroNote) {
@@ -241,7 +261,18 @@ function analyzeHighlightedNotes() {
 populateSelectors();
 renderFretboard();
 
-['notesInput','scaleRootSelect','scaleSelect','tuningInput','fretsInput','highlightRootToggle','showAllNotesToggle','pitchColorsToggle','groupBySelect'].forEach(id => {
+[
+  'notesInput',
+  'scaleRootSelect',
+  'scaleSelect',
+  'tuningInput',
+  'fretsInput',
+  'highlightRootToggle',
+  'showAllNotesToggle',
+  'pitchColorsToggle',
+  'relativeColorsToggle',
+  'groupBySelect'
+].forEach(id => {
   const el = document.getElementById(id);
   if (!el) return;
   el.addEventListener('change', () => {

--- a/fretboard.js
+++ b/fretboard.js
@@ -53,8 +53,9 @@ function renderFretboard() {
   const scaleName = document.getElementById('scaleSelect').value;
   const showAll = document.getElementById('showAllNotesToggle').checked;
   const highlightRootToggle = document.getElementById('highlightRootToggle').checked;
-  const pitchToggle = document.getElementById('pitchColorsToggle').checked;
-  const relativeToggle = document.getElementById('relativeColorsToggle')?.checked;
+  const colorMode = document.getElementById('colorModeSelect')?.value || '';
+  const pitchColorsEnabled = colorMode !== '';
+  const relativeColorsEnabled = colorMode === 'relative';
 
   const rootVal = noteMap[scaleRootName] ?? '';
 
@@ -71,7 +72,7 @@ function renderFretboard() {
   }
 
   const scaleDegreeColorMap = new Map();
-  if (relativeToggle && scaleNotes.length) {
+  if (relativeColorsEnabled && scaleNotes.length) {
     scaleNotes.forEach((note, index) => {
       if (!scaleDegreeColorMap.has(note)) {
         scaleDegreeColorMap.set(note, scaleDegreeColors[index % scaleDegreeColors.length]);
@@ -80,8 +81,8 @@ function renderFretboard() {
   }
 
   const getRingColor = (note) => {
-    if (!pitchToggle) return null;
-    if (scaleDegreeColorMap.size && scaleDegreeColorMap.has(note)) {
+    if (!pitchColorsEnabled) return null;
+    if (relativeColorsEnabled && scaleDegreeColorMap.size && scaleDegreeColorMap.has(note)) {
       return scaleDegreeColorMap.get(note);
     }
     return pitchColors[note];
@@ -269,8 +270,7 @@ renderFretboard();
   'fretsInput',
   'highlightRootToggle',
   'showAllNotesToggle',
-  'pitchColorsToggle',
-  'relativeColorsToggle',
+  'colorModeSelect',
   'groupBySelect'
 ].forEach(id => {
   const el = document.getElementById(id);

--- a/index.html
+++ b/index.html
@@ -19,8 +19,13 @@
   <label>Highlight Root: <input type="checkbox" id="highlightRootToggle"/></label>
   <label>Scale: <select id="scaleSelect"></select></label>
   <label>Show All Notes: <input type="checkbox" id="showAllNotesToggle"/></label>
-  <label>Pitch Colors: <input type="checkbox" id="pitchColorsToggle" /></label>
-  <label>Relative Scale Colors: <input type="checkbox" id="relativeColorsToggle" /></label>
+  <label>Color Mode:
+    <select id="colorModeSelect">
+      <option value="">None</option>
+      <option value="absolute">Absolute Pitch Colors</option>
+      <option value="relative">Relative Scale Colors</option>
+    </select>
+  </label>
 
 </div>
 <div class="fretboard-wrapper">

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <label>Scale: <select id="scaleSelect"></select></label>
   <label>Show All Notes: <input type="checkbox" id="showAllNotesToggle"/></label>
   <label>Pitch Colors: <input type="checkbox" id="pitchColorsToggle" /></label>
+  <label>Relative Scale Colors: <input type="checkbox" id="relativeColorsToggle" /></label>
 
 </div>
 <div class="fretboard-wrapper">


### PR DESCRIPTION
## Summary
- add a UI toggle to select between absolute pitch colors and scale-relative colors
- derive ring highlight colors from the current scale degree ordering when the relative toggle is enabled

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69083fcd86d0832eb18824ae6781cc1d