### PR TITLE
Fix relative scale degree color mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,13 @@
   <label>Highlight Root: <input type="checkbox" id="highlightRootToggle"/></label>
   <label>Scale: <select id="scaleSelect"></select></label>
   <label>Show All Notes: <input type="checkbox" id="showAllNotesToggle"/></label>
-  <label>Pitch Colors: <input type="checkbox" id="pitchColorsToggle" /></label>
+  <label>Color Mode:
+    <select id="colorModeSelect">
+      <option value="">None</option>
+      <option value="absolute">Absolute Pitch Colors</option>
+      <option value="relative">Relative Scale Colors</option>
+    </select>
+  </label>
 
 </div>
 <div class="fretboard-wrapper">


### PR DESCRIPTION
## Summary
- update the relative color mode to derive degree colors from the base C-root version of the selected scale so each degree keeps a consistent hue
- fall back to absolute pitch colors if a degree color cannot be resolved

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69083fcd86d0832eb18824ae6781cc1d