### PR TITLE
Add Sato Mode toggle to reveal advanced controls

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -289,7 +289,7 @@ if (satoModeButton) {
   const body = document.body;
   const updateSatoModeButton = () => {
     const engaged = body.classList.contains('sato-mode-engaged');
-    satoModeButton.textContent = engaged ? 'Sato Mode: Engaged' : 'Sato Mode';
+    satoModeButton.textContent = engaged ? 'Engaged' : 'Sato Mode';
     satoModeButton.classList.toggle('engaged', engaged);
     satoModeButton.setAttribute('aria-pressed', engaged ? 'true' : 'false');
   };

--- a/fretboard.js
+++ b/fretboard.js
@@ -283,3 +283,21 @@ renderFretboard();
     renderFretboard();
   });
 });
+
+const satoModeButton = document.getElementById('satoModeButton');
+if (satoModeButton) {
+  const body = document.body;
+  const updateSatoModeButton = () => {
+    const engaged = body.classList.contains('sato-mode-engaged');
+    satoModeButton.textContent = engaged ? 'Sato Mode: Engaged' : 'Sato Mode';
+    satoModeButton.classList.toggle('engaged', engaged);
+    satoModeButton.setAttribute('aria-pressed', engaged ? 'true' : 'false');
+  };
+
+  satoModeButton.addEventListener('click', () => {
+    body.classList.toggle('sato-mode-engaged');
+    updateSatoModeButton();
+  });
+
+  updateSatoModeButton();
+}

--- a/index.html
+++ b/index.html
@@ -13,10 +13,10 @@
 <h1>Fret Boar</h1>
 <div class="controls">
   <label>Tuning: <input id="tuningInput" type="text" value="E A D G B E" /></label>
-  <label>Frets: <input id="fretsInput" type="number" value="24" min="1" max="30" /></label>
+  <label class="advanced-control">Frets: <input id="fretsInput" type="number" value="24" min="1" max="30" /></label>
   <label>Highlight Notes: <input id="notesInput" type="text" value="" /></label>
   <label>Scale Root: <select id="scaleRootSelect"></select></label>
-  <label>Highlight Root: <input type="checkbox" id="highlightRootToggle"/></label>
+  <label class="advanced-control">Highlight Root: <input type="checkbox" id="highlightRootToggle"/></label>
   <label>Scale: <select id="scaleSelect"></select></label>
   <label class="advanced-control">Show All Notes: <input type="checkbox" id="showAllNotesToggle"/></label>
   <label class="advanced-control">Color Mode:

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
   <label>Scale Root: <select id="scaleRootSelect"></select></label>
   <label>Highlight Root: <input type="checkbox" id="highlightRootToggle"/></label>
   <label>Scale: <select id="scaleSelect"></select></label>
-  <label>Show All Notes: <input type="checkbox" id="showAllNotesToggle"/></label>
-  <label>Color Mode:
+  <label class="advanced-control">Show All Notes: <input type="checkbox" id="showAllNotesToggle"/></label>
+  <label class="advanced-control">Color Mode:
     <select id="colorModeSelect">
       <option value="">None</option>
       <option value="absolute">Absolute Pitch Colors</option>
@@ -71,17 +71,20 @@
 <p>Fret Boar is an interactive tool to help fretted instrument players learn and practice. Simply tap/click on some notes, or enter them in the "Highlight Notes" to have them appear on the fretboard. The fretboard is interactive and responsive to the settings. Select a scale from the dropdown or analysis output to highlight every note of the scale on the fretboard.</p>
 <p>Metro Gnome is a fully functional metronome, and integrates with Fret Boar to sequence the fretboard visually and/or audibly. "Add Measure" can be used to create sequences of different rhythms with different time signatures and tempos, looping through the measures. Each beat can have its frequency set, or you can have it match the frequency of the synchronized note on the fretboard.</p>
 <div id="footerBanner">
-  <a href="https://necrosato.github.io/metrognome" target="_blank" rel="noopener noreferrer">
-    Metro Gnome V1
-  </a>
- - 
-  <a href="https://necrosato.github.io/fretboar" target="_blank" rel="noopener noreferrer">
-    Fret Boar V1
-  </a>
- - 
-  <a href="https://necrosato.github.io/pianotroll" target="_blank" rel="noopener noreferrer">
-    Piano Troll V1
-  </a>
+  <div class="footer-links">
+    <a href="https://necrosato.github.io/metrognome" target="_blank" rel="noopener noreferrer">
+      Metro Gnome V1
+    </a>
+    <span>-</span>
+    <a href="https://necrosato.github.io/fretboar" target="_blank" rel="noopener noreferrer">
+      Fret Boar V1
+    </a>
+    <span>-</span>
+    <a href="https://necrosato.github.io/pianotroll" target="_blank" rel="noopener noreferrer">
+      Piano Troll V1
+    </a>
+  </div>
+  <button id="satoModeButton" type="button" aria-pressed="false">Sato Mode</button>
 </div>
 
 </body>

--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,20 @@ button:hover {
   margin-bottom: 1rem;
 }
 
+.controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.controls .advanced-control {
+  display: none;
+}
+
+body.sato-mode-engaged .controls .advanced-control {
+  display: inline-flex;
+}
+
 .controls input,
 .controls select,
 .controls button,
@@ -241,6 +255,11 @@ button:hover {
   bottom: 0;
   left: 0;
   width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
   background: #222;
   color: #eee;
   text-align: center;
@@ -254,6 +273,25 @@ button:hover {
 #footerBanner a {
   color: #4CAF50;
   text-decoration: none;
+}
+
+#footerBanner .footer-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#footerBanner button {
+  background: #333;
+  border: 1px solid #4CAF50;
+  color: #4CAF50;
+}
+
+#satoModeButton.engaged,
+body.sato-mode-engaged #satoModeButton {
+  background: #4CAF50;
+  border-color: #81C784;
+  color: #111;
 }
 
 #footerBanner a:hover {

--- a/styles.css
+++ b/styles.css
@@ -287,6 +287,10 @@ body.sato-mode-engaged .controls .advanced-control {
   color: #4CAF50;
 }
 
+#satoModeButton {
+  width: 120px;
+}
+
 #satoModeButton.engaged,
 body.sato-mode-engaged #satoModeButton {
   background: #4CAF50;


### PR DESCRIPTION
## Summary
- add a Sato Mode button in the footer that toggles advanced controls
- hide the Show All Notes and Color Mode controls by default and restyle the footer layout
- update the fretboard script to manage Sato Mode state and button labeling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6908de83eec8832e852cbfb36cd8091c