### PR TITLE
Add configurable note highlight colors in Sato mode

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -266,6 +266,28 @@ function analyzeHighlightedNotes() {
 populateSelectors();
 renderFretboard();
 
+const noteColorControls = [
+  { id: 'highlightColorInput', variable: '--highlight-color', defaultColor: '#f39c12' },
+  { id: 'rootColorInput', variable: '--root-color', defaultColor: '#e74c3c' },
+  { id: 'scaleColorInput', variable: '--scale-color', defaultColor: '#9b59b6' },
+  { id: 'metroColorInput', variable: '--metro-color', defaultColor: '#4caf50' }
+];
+
+const applyNoteColors = () => {
+  noteColorControls.forEach(({ id, variable, defaultColor }) => {
+    const control = document.getElementById(id);
+    const value = control?.value || defaultColor;
+    document.documentElement.style.setProperty(variable, value);
+  });
+};
+applyNoteColors();
+
+noteColorControls.forEach(({ id }) => {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.addEventListener('input', applyNoteColors);
+});
+
 [
   'notesInput',
   'scaleRootSelect',

--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
       <option value="relative">Relative Scale Colors</option>
     </select>
   </label>
+  <label class="advanced-control">Highlight Color: <input id="highlightColorInput" type="color" value="#f39c12" /></label>
+  <label class="advanced-control">Root Color: <input id="rootColorInput" type="color" value="#e74c3c" /></label>
+  <label class="advanced-control">Scale Color: <input id="scaleColorInput" type="color" value="#9b59b6" /></label>
+  <label class="advanced-control">Metronome Color: <input id="metroColorInput" type="color" value="#4caf50" /></label>
 
 </div>
 <div class="fretboard-wrapper">

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,13 @@
 /* ================================
    Base Layout & Typography
 ================================== */
+:root {
+  --highlight-color: #f39c12;
+  --root-color: #e74c3c;
+  --scale-color: #9b59b6;
+  --metro-color: #4caf50;
+}
+
 body {
   font-family: monospace;
   background-color: #1e1e1e;
@@ -179,23 +186,23 @@ body.sato-mode-engaged .controls .advanced-control {
 }
 
 .fret.highlight::before {
-  background-color: #f39c12;
-  box-shadow: 0 0 10px #f39c12;
+  background-color: var(--highlight-color, #f39c12);
+  box-shadow: 0 0 10px var(--highlight-color, #f39c12);
 }
 
 .fret.root-highlight::before {
-  background-color: #e74c3c;
-  box-shadow: 0 0 10px #e74c3c;
+  background-color: var(--root-color, #e74c3c);
+  box-shadow: 0 0 10px var(--root-color, #e74c3c);
 }
 
 .fret.scale-highlight::before {
-  background-color: #9b59b6;
-  box-shadow: 0 0 10px #9b59b6;
+  background-color: var(--scale-color, #9b59b6);
+  box-shadow: 0 0 10px var(--scale-color, #9b59b6);
 }
 
 .fret.metro-highlight::before {
-  background-color: #4CAF50;
-  box-shadow: 0 0 10px #4CAF50;
+  background-color: var(--metro-color, #4caf50);
+  box-shadow: 0 0 10px var(--metro-color, #4caf50);
 }
 
 /* ================================
@@ -204,25 +211,25 @@ body.sato-mode-engaged .controls .advanced-control {
 .fret.open {
   font-weight: bold;
   background-color: #333;
-  border: 2px solid #f39c12;
-  box-shadow: inset 0 0 5px #f39c12;
+  border: 2px solid var(--highlight-color, #f39c12);
+  box-shadow: inset 0 0 5px var(--highlight-color, #f39c12);
   z-index: 1;
 }
 
 .fret.open.highlight {
-  box-shadow: inset 0 0 5px #f39c12;
+  box-shadow: inset 0 0 5px var(--highlight-color, #f39c12);
 }
 
 .fret.open.scale-highlight {
-  box-shadow: inset 0 0 5px #9b59b6;
+  box-shadow: inset 0 0 5px var(--scale-color, #9b59b6);
 }
 
 .fret.open.root-highlight {
-  box-shadow: inset 0 0 5px #e74c3c;
+  box-shadow: inset 0 0 5px var(--root-color, #e74c3c);
 }
 
 .fret.open.metro-highlight {
-  box-shadow: inset 0 0 5px #4CAF50;
+  box-shadow: inset 0 0 5px var(--metro-color, #4caf50);
 }
 
 /* ================================


### PR DESCRIPTION
## Summary
- add Sato mode color pickers to configure highlight, root, scale, and metronome notes
- wire color pickers to CSS variables that drive fret marker styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69090c2b6fac832ebcab58e654864ba0