### PR TITLE
Style color inputs as circular swatches

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -278,6 +278,9 @@ const applyNoteColors = () => {
     const control = document.getElementById(id);
     const value = control?.value || defaultColor;
     document.documentElement.style.setProperty(variable, value);
+    if (control) {
+      control.style.setProperty('--current-color', value);
+    }
   });
 };
 applyNoteColors();

--- a/styles.css
+++ b/styles.css
@@ -70,6 +70,32 @@ body.sato-mode-engaged .controls .advanced-control {
   border-radius: 4px;
 }
 
+.controls input[type="color"] {
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  background: none;
+  cursor: pointer;
+  box-shadow: 0 0 10px var(--current-color, rgba(255, 255, 255, 0.35));
+}
+
+.controls input[type="color"]::-webkit-color-swatch-wrapper {
+  padding: 0;
+  border-radius: 50%;
+}
+
+.controls input[type="color"]::-webkit-color-swatch {
+  border: none;
+  border-radius: 50%;
+}
+
+.controls input[type="color"]::-moz-color-swatch {
+  border: none;
+  border-radius: 50%;
+}
+
 .controls #scaleRootSelect {
   width: 60px;
 }


### PR DESCRIPTION
## Summary
- style the color controls as circular swatches to match fretboard markers
- update note color handling to sync the swatch glow with the selected color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a3051eecc832e89eb085fb251fbbc