### PR TITLE
Show ring color selectors only when color mode enabled

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -273,6 +273,18 @@ const noteColorControls = [
   { id: 'metroColorInput', variable: '--metro-color', defaultColor: '#4caf50' }
 ];
 
+const ringColorSelectors = noteColorControls
+  .map(({ id }) => document.getElementById(id)?.closest('label'))
+  .filter(Boolean);
+
+const updateRingColorSelectorsVisibility = () => {
+  const colorModeValue = document.getElementById('colorModeSelect')?.value || '';
+  const shouldShow = colorModeValue !== '';
+  ringColorSelectors.forEach(label => {
+    label.style.display = shouldShow ? 'inline-flex' : 'none';
+  });
+};
+
 const applyNoteColors = () => {
   noteColorControls.forEach(({ id, variable, defaultColor }) => {
     const control = document.getElementById(id);
@@ -284,6 +296,7 @@ const applyNoteColors = () => {
   });
 };
 applyNoteColors();
+updateRingColorSelectorsVisibility();
 
 noteColorControls.forEach(({ id }) => {
   const el = document.getElementById(id);
@@ -305,6 +318,9 @@ noteColorControls.forEach(({ id }) => {
   const el = document.getElementById(id);
   if (!el) return;
   el.addEventListener('change', () => {
+    if (id === 'colorModeSelect') {
+      updateRingColorSelectorsVisibility();
+    }
     renderFretboard();
   });
 });

--- a/fretboard.js
+++ b/fretboard.js
@@ -305,11 +305,30 @@ if (ringColorControlsContainer) {
   });
 }
 
+const noteColorLabels = noteColorControls
+  .map(({ id }) => document.getElementById(id)?.closest('label'))
+  .filter(Boolean);
+
+const syncNoteColorLabelVisibility = () => {
+  const engaged = document.body.classList.contains('sato-mode-engaged');
+  noteColorLabels.forEach(label => {
+    if (!label) return;
+    label.style.display = engaged ? 'inline-flex' : 'none';
+    label.setAttribute('aria-hidden', engaged ? 'false' : 'true');
+  });
+};
+
 const updateRingColorSelectorsVisibility = () => {
   if (!ringColorControlsContainer) return;
   const colorModeValue = document.getElementById('colorModeSelect')?.value || '';
-  const shouldShow = colorModeValue !== '';
+  const satoEngaged = document.body.classList.contains('sato-mode-engaged');
+  const shouldShow = satoEngaged && colorModeValue !== '';
   ringColorControlsContainer.classList.toggle('hidden', !shouldShow);
+  ringColorControlsContainer.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+  ringColorControls.forEach(({ input }) => {
+    if (!input) return;
+    input.tabIndex = shouldShow ? 0 : -1;
+  });
 };
 
 const applyRingColors = () => {
@@ -334,6 +353,7 @@ const applyNoteColors = () => {
 applyNoteColors();
 updateRingColorSelectorsVisibility();
 applyRingColors();
+syncNoteColorLabelVisibility();
 
 noteColorControls.forEach(({ id }) => {
   const el = document.getElementById(id);
@@ -380,6 +400,8 @@ if (satoModeButton) {
     satoModeButton.textContent = engaged ? 'Engaged' : 'Sato Mode';
     satoModeButton.classList.toggle('engaged', engaged);
     satoModeButton.setAttribute('aria-pressed', engaged ? 'true' : 'false');
+    syncNoteColorLabelVisibility();
+    updateRingColorSelectorsVisibility();
   };
 
   satoModeButton.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
   <label class="advanced-control">Root Color: <input id="rootColorInput" type="color" value="#e74c3c" /></label>
   <label class="advanced-control">Scale Color: <input id="scaleColorInput" type="color" value="#9b59b6" /></label>
   <label class="advanced-control">Metronome Color: <input id="metroColorInput" type="color" value="#4caf50" /></label>
-  <div id="ringColorControls" class="advanced-control ring-color-controls hidden"></div>
+  <div id="ringColorControls" class="ring-color-controls hidden" aria-hidden="true"></div>
 
 </div>
 <div class="fretboard-wrapper">

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
   <label class="advanced-control">Root Color: <input id="rootColorInput" type="color" value="#e74c3c" /></label>
   <label class="advanced-control">Scale Color: <input id="scaleColorInput" type="color" value="#9b59b6" /></label>
   <label class="advanced-control">Metronome Color: <input id="metroColorInput" type="color" value="#4caf50" /></label>
+  <div id="ringColorControls" class="advanced-control ring-color-controls hidden"></div>
 
 </div>
 <div class="fretboard-wrapper">

--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,27 @@ button:hover {
   gap: 0.5rem;
 }
 
+.ring-color-controls {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.ring-color-controls.hidden {
+  display: none !important;
+}
+
+.ring-color-controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.ring-color-controls > span {
+  font-weight: bold;
+  width: 100%;
+}
+
 .controls .advanced-control {
   display: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,10 @@ button:hover {
   gap: 0.5rem;
 }
 
+body:not(.sato-mode-engaged) .ring-color-controls {
+  display: none;
+}
+
 .ring-color-controls.hidden {
   display: none !important;
 }


### PR DESCRIPTION
## Summary
- hide the note ring color selectors until a color mode is chosen
- update the selectors' visibility whenever the color mode changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a318dae5c832eaf12233a2dac9ce8