### PR TITLE
Hide sequence file controls behind Sato mode

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -433,11 +433,23 @@ if (ringColorControlsContainer) {
 const satoModeButton = document.getElementById('satoModeButton');
 if (satoModeButton) {
   const body = document.body;
+  const updateSatoOnlyElements = (engaged) => {
+    document.querySelectorAll('.sato-only').forEach((element) => {
+      element.setAttribute('aria-hidden', engaged ? 'false' : 'true');
+      if (!engaged) {
+        element.setAttribute('tabindex', '-1');
+      } else {
+        element.removeAttribute('tabindex');
+      }
+    });
+  };
+
   const updateSatoModeButton = () => {
     const engaged = body.classList.contains('sato-mode-engaged');
     satoModeButton.textContent = engaged ? 'Engaged' : 'Sato Mode';
     satoModeButton.classList.toggle('engaged', engaged);
     satoModeButton.setAttribute('aria-pressed', engaged ? 'true' : 'false');
+    updateSatoOnlyElements(engaged);
     syncNoteColorLabelVisibility();
     updateRingColorSelectorsVisibility();
   };

--- a/index.html
+++ b/index.html
@@ -64,8 +64,8 @@
       <button id="start">Start</button>
       <button id="stop">Stop</button>
       <button id="add-measure">Add Measure</button><br>
-      <button id="load-sequence">Load Sequence</button>
-      <button id="save-sequence">Save Sequence</button>
+      <button id="load-sequence" class="sato-only" aria-hidden="true">Load Sequence</button>
+      <button id="save-sequence" class="sato-only" aria-hidden="true">Save Sequence</button>
       <input type="file" id="file-input" style="display: none;"><br>
   	  <label>Override Tone to Synchronized Note: <input type="checkbox" id="overrideToneToggle"/></label>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,14 @@ body.sato-mode-engaged .controls .advanced-control {
   display: inline-flex;
 }
 
+.sato-only {
+  display: none !important;
+}
+
+body.sato-mode-engaged .sato-only {
+  display: inline-flex !important;
+}
+
 .controls input,
 .controls select,
 .controls button,


### PR DESCRIPTION
## Summary
- hide the metronome sequence load/save controls unless Sato Mode is engaged
- ensure Sato Mode toggling updates accessibility attributes on the sequence controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c077ee0f4832e997704032fe04328