### PR TITLE
Hide measure tone controls when Sato mode is off

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -443,6 +443,7 @@ if (satoModeButton) {
       }
     });
   };
+  window.updateSatoOnlyElements = updateSatoOnlyElements;
 
   const updateSatoModeButton = () => {
     const engaged = body.classList.contains('sato-mode-engaged');

--- a/metrognome.js
+++ b/metrognome.js
@@ -183,24 +183,25 @@ class Metronome {
       }, 30);
 
       div.append(tempoInput, document.createElement("br"), tsNumInput, tsDenInput);
-		const toneContainer = document.createElement('div');
-		toneContainer.className = 'tone-column';
+      const toneContainer = document.createElement('div');
+      toneContainer.className = 'tone-column';
+      toneContainer.classList.add('sato-only');
 
-                for (let i = 0; i < measure.timeSignature[0]; i++) {
-                  const toneVal = measure.tones[i] ?? (i === 0 ? 880 : 440);
-                  measure.tones[i] = toneVal;
+      for (let i = 0; i < measure.timeSignature[0]; i++) {
+        const toneVal = measure.tones[i] ?? (i === 0 ? 880 : 440);
+        measure.tones[i] = toneVal;
 
-                  const toneInput = this.createInput(toneVal, `B${i + 1}: `, val => {
-                        this.sequence[index].tones[i] = parseFloat(val) || 0;
-                  }, 60);
+        const toneInput = this.createInput(toneVal, `B${i + 1}: `, val => {
+          this.sequence[index].tones[i] = parseFloat(val) || 0;
+        }, 60);
 
-                  const inputElement = toneInput.querySelector('input');
-                  inputElement.dataset.measureIndex = index;
-                  inputElement.dataset.beatIndex = i;
+        const inputElement = toneInput.querySelector('input');
+        inputElement.dataset.measureIndex = index;
+        inputElement.dataset.beatIndex = i;
 
-                  toneContainer.appendChild(toneInput);
-                }
-                div.appendChild(toneContainer);
+        toneContainer.appendChild(toneInput);
+      }
+      div.appendChild(toneContainer);
       const deleteButton = document.createElement('button');
       deleteButton.textContent = 'Delete';
       deleteButton.onclick = () => this.deleteMeasure(index);
@@ -208,6 +209,9 @@ class Metronome {
 
       measuresContainer.appendChild(div);
     });
+    if (typeof window.updateSatoOnlyElements === 'function') {
+      window.updateSatoOnlyElements(document.body.classList.contains('sato-mode-engaged'));
+    }
     this.updateActiveBeatHighlight();
   }
 

--- a/styles.css
+++ b/styles.css
@@ -92,6 +92,10 @@ body.sato-mode-engaged .sato-only {
   display: inline-flex !important;
 }
 
+body.sato-mode-engaged .tone-column.sato-only {
+  display: flex !important;
+}
+
 .controls input,
 .controls select,
 .controls button,


### PR DESCRIPTION
## Summary
- hide metronome measure tone frequency inputs unless Sato mode is engaged
- expose the Sato-only toggle helper so newly rendered controls inherit its accessibility settings
- ensure Sato-mode tone columns keep their flex layout when shown

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_690c090b1388832ea192e85088436253