### PR TITLE
Add Sato mode control for metronome beep duration

### DIFF
--- a/fretboard.js
+++ b/fretboard.js
@@ -441,6 +441,19 @@ if (satoModeButton) {
       } else {
         element.removeAttribute('tabindex');
       }
+
+      if (element.matches('input, select, button, textarea')) {
+        element.disabled = !engaged;
+      }
+
+      element.querySelectorAll('input, select, button, textarea').forEach(control => {
+        control.disabled = !engaged;
+        if (!engaged) {
+          control.setAttribute('tabindex', '-1');
+        } else {
+          control.removeAttribute('tabindex');
+        }
+      });
     });
   };
   window.updateSatoOnlyElements = updateSatoOnlyElements;

--- a/index.html
+++ b/index.html
@@ -68,15 +68,8 @@
       <button id="save-sequence" class="sato-only" aria-hidden="true">Save Sequence</button>
       <input type="file" id="file-input" style="display: none;"><br>
           <label>Override Tone to Synchronized Note: <input type="checkbox" id="overrideToneToggle"/></label>
-          <label class="sato-only" aria-hidden="true">Beep Length (ms):
-            <input
-              id="beepLengthInput"
-              type="number"
-              min="20"
-              max="2000"
-              step="10"
-              value="100"
-            />
+          <label class="sato-only" aria-hidden="true">Legato:
+            <input type="checkbox" id="legatoToggle" />
           </label>
     </div>
     <div id="measures"></div>

--- a/index.html
+++ b/index.html
@@ -67,7 +67,17 @@
       <button id="load-sequence" class="sato-only" aria-hidden="true">Load Sequence</button>
       <button id="save-sequence" class="sato-only" aria-hidden="true">Save Sequence</button>
       <input type="file" id="file-input" style="display: none;"><br>
-  	  <label>Override Tone to Synchronized Note: <input type="checkbox" id="overrideToneToggle"/></label>
+          <label>Override Tone to Synchronized Note: <input type="checkbox" id="overrideToneToggle"/></label>
+          <label class="sato-only" aria-hidden="true">Beep Length (ms):
+            <input
+              id="beepLengthInput"
+              type="number"
+              min="20"
+              max="2000"
+              step="10"
+              value="100"
+            />
+          </label>
     </div>
     <div id="measures"></div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -415,6 +415,22 @@ body.sato-mode-engaged #satoModeButton {
   flex: 1;
 }
 
+#metronome-controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.25rem 0;
+}
+
+#metronome-controls input[type="number"] {
+  background: #333;
+  color: white;
+  border: 1px solid #666;
+  padding: 4px 8px;
+  border-radius: 4px;
+  width: 80px;
+}
+
 .measure {
   display: inline-block;
   margin: 1rem;

--- a/styles.css
+++ b/styles.css
@@ -486,6 +486,22 @@ input.active-beat {
   margin-top: 0.5rem;
 }
 
+.beat-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.beat-row label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+body.legato-enabled .beat-duration {
+  display: none !important;
+}
+
 /* ================================
    Responsive Layout
 ================================== */


### PR DESCRIPTION
## Summary
- add a Sato-mode-only metronome control to set the beep length
- wire the metronome engine to respect the configurable beep duration and smooth its envelope
- disable Sato-only controls when the mode is off and polish metronome control styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690ceb2043a0832e9c955b1d01611058